### PR TITLE
Use ubuntu-latest instead of self-hosted

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,8 +15,7 @@ env:
 
 jobs:
   build:
-    # runs-on: ubuntu-latest
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     defaults:
       run:
@@ -45,8 +44,7 @@ jobs:
 
   deploy:
     needs: build
-    # runs-on: ubuntu-latest
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -18,8 +18,7 @@ env:
 jobs:
   run:
     name: Run xbox-cloud-statistics
-    # runs-on: ubuntu-latest
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ${{ env.BACKEND_PATH }}


### PR DESCRIPTION
Since this repo is about to go public, the self-hosted runner can be replaced by GitHubs runner