### PR TITLE
Fix video in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For setup and usage please refer to [backend/README](./backend/README.md).
 
 For setup and usage please refer to [frontend/README](./frontend/README.md).
 
-https://github.com/n-thumann/xbox-cloud-statistics/assets/46975855/2ebcaf82-8e68-4cf4-845c-95bfab6766ef
+https://github.com/n-thumann/xbox-cloud-statistics/assets/46975855/f173ae53-e495-4f3d-9ba1-c837952141a0
 
 ## Measurement data
 


### PR DESCRIPTION
This PR fixes the video in README. It must have been deleted while deleting and recreating this repo.