### PR TITLE
Add sorting for Game

### DIFF
--- a/backend/xbox_cloud_statistics/models.py
+++ b/backend/xbox_cloud_statistics/models.py
@@ -37,6 +37,12 @@ class Game(Model):
     def to_dict(self) -> dict:
         return {"id": self.id, "title": self.title, "image_url": self.image_url}
 
+    def __lt__(self, other) -> bool:
+        if not isinstance(other, Game):
+            raise TypeError
+
+        return self.id < other.id
+
 
 @dataclass(frozen=True)
 class Measurement(Model):
@@ -126,7 +132,7 @@ class Results(Model):
         return self._games[game]
 
     def __iter__(self) -> Iterator[tuple[Game, GameResult]]:
-        return iter(self._games.items())
+        return iter(sorted(self._games.items()))
 
     def to_dict(self) -> dict:
         return {game.id: game_result for game, game_result in self}


### PR DESCRIPTION
This PR adds sort of Game objects. This results in the games being sorted in both the `meta.json` file (and hence the frontend) and also the CLI output.