### PR TITLE
Fix: Growing repository by only keeping the latest commit

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -50,6 +50,7 @@ jobs:
           LAST_UPDATE=$(date --utc --date "@$(jq .last_update meta.json)")
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout --orphan work
           git add .
           git commit -m "Update results ($LAST_UPDATE)"
-          git push
+          git push --force origin work:results


### PR DESCRIPTION
This PR tries to fix the ever growing repository size by only keeping the latest commit of the `results` branch.

The repository is currently over 15 GB in size due to all the history kept in the `results` branch. This isn't actually needed, because the JSON files itself store all historic data.