### PR TITLE
Fix: File title casing

### DIFF
--- a/frontend/modules/body-content/transformer.ts
+++ b/frontend/modules/body-content/transformer.ts
@@ -5,9 +5,11 @@ export default defineTransformer({
   name: "body-transformer",
   extensions: [".json"],
   parse: (_id: string, content: any) => {
+    const path = _id.split(":");
     return {
+      title: path[path.length - 1].slice(0, -5),
       body: content,
-      path: _id.split(":"),
+      path,
       _id,
     };
   },


### PR DESCRIPTION
This PR fixes the file title casing.
It was the same as the actual file name in the past (e.g. `FORTNITE/AustraliaEast/F2P.json` had file name `F2P`), however something in https://github.com/n-thumann/xbox-cloud-statistics/pull/21 changed this so that the file name now is in pascal case (e.g. `F2p` or `Gpu`).
This also breaks the coloring of lines in the diagram:
![image](https://github.com/n-thumann/xbox-cloud-statistics/assets/46975855/e71aec2f-4edd-4e92-ba36-954dea8a438d)
