### PR TITLE
Fix: Links to games on index

### DIFF
--- a/frontend/site_generator/templates/index.html
+++ b/frontend/site_generator/templates/index.html
@@ -9,7 +9,7 @@
 
         <div class="grid gap-4 grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:gap-6">
             {% for game in games %}
-            <a href="/games/{{ game.id }}.html" title="{{ game.title }}" class="overflow-hidden relative group/game">
+            <a href="games/{{ game.id }}.html" title="{{ game.title }}" class="overflow-hidden relative group/game">
                 <img src="{{ game.image_url }}" title="{{ game.title }}" class="transition-transform duration-700 group-hover/game:scale-110 group-hover/game:rotate-2" />
 
                 <div class="absolute inset-0 bg-xbox h-full w-full transition-opacity duration-700 opacity-0 group-hover/game:opacity-50"></div>


### PR DESCRIPTION
This PR fixes the links on the index page, because I've broken them as part of https://github.com/n-thumann/xbox-cloud-statistics/pull/42.
This is caused by GitHub pages appending the project name to the domain, which I didn't took into account.