### PR TITLE
Change: Update Actions used in workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,8 +21,8 @@ jobs:
       run:
         working-directory: ${{ env.FRONTEND_PATH }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           ref: results
           path: ${{ env.FRONTEND_PATH}}/results/
@@ -38,7 +38,7 @@ jobs:
       - name: Run site-generator
         run: poetry run site-generator
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ${{ env.FRONTEND_PATH }}/dist/
 

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -23,8 +23,8 @@ jobs:
       run:
         working-directory: ${{ env.BACKEND_PATH }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
         with:
           ref: results
           path: ${{ env.BACKEND_PATH}}/results


### PR DESCRIPTION
This PR tries to fix:
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v4, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```