### PR TITLE
Fix: Miscellaneous minor fixes

### DIFF
--- a/frontend/site_generator/templates/base.html
+++ b/frontend/site_generator/templates/base.html
@@ -2,6 +2,11 @@
 <meta charset="utf-8">
 <html>
     <head>
+        {% if title is defined %}
+            <title>{{ title }} - Xbox Cloud Statistics</title>
+        {% else %}
+            <title>Xbox Cloud Statistics</title>
+        {% endif %}
         {% for script in scripts %}
         <script>{{ script }}</script>
         {% endfor %}
@@ -9,7 +14,6 @@
         <style>{{ style }}</style>
         {% endfor %}
     </head>
-    {% endblock %}
 <body>
     <div class="min-h-screen flex flex-col">
         {% block content required %}{% endblock %}

--- a/frontend/site_generator/templates/base.html
+++ b/frontend/site_generator/templates/base.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
+<meta charset="utf-8">
 <html>
-    {% block header %}
     <head>
         {% for script in scripts %}
         <script>{{ script }}</script>

--- a/frontend/site_generator/templates/game.html
+++ b/frontend/site_generator/templates/game.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
     <div class="max-w-6xl p-8 lg:self-center lg:w-[72rem]">
-        <a href="/" title="homepage" class="mb-6 text-5xl">
+        <a href="../" title="homepage" class="mb-6 text-5xl">
             &lsaquo;
         </a>
         <h1 class="text-3xl font-bold uppercase text-center pb-2 lg:text-4xl">


### PR DESCRIPTION
This PR implements some minor fixes:
- Explicitly specify HTML page encoding. Otherwise game titles might be like `Tom Clancyâ€™s Ghost ReconÂ® Wildlands - Standard Edition` on the local development server
- Fixes a broken back link, because GitHub appends this repos name to the path
- Fixes the previously set, but in the new site generator missing HTML title