### PR TITLE
Reschedule and adjust Dependabot to new frontend

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/backend"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       backend-dependendcies:
         patterns:
@@ -11,7 +11,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/frontend"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       frontend-dependendcies:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
       backend-dependendcies:
         patterns:
           - "*"
-  - package-ecosystem: "npm"
+  - package-ecosystem: "pip"
     directory: "/frontend"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This PR
- adjusts Dependabot to the new Python-based frontend (since https://github.com/n-thumann/xbox-cloud-statistics/pull/42)
- reschedules Dependabot to make it run monthly instead of weekly