### PR TITLE
Use release for results

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  GH_TOKEN: ${{ github.token }}
   FRONTEND_PATH: frontend
   RESULTS_FILE_NAME: results.tar.gz
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,7 @@ concurrency:
 
 env:
   FRONTEND_PATH: frontend
+  RESULTS_FILE_NAME: results.tar.gz
 
 jobs:
   build:
@@ -22,10 +23,10 @@ jobs:
         working-directory: ${{ env.FRONTEND_PATH }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
-        with:
-          ref: results
-          path: ${{ env.FRONTEND_PATH}}/results/
+      - name: Download results
+        run: |
+          gh release download results --pattern ${{ env.RESULTS_FILE_NAME }}
+          tar -xzf ${{ env.RESULTS_FILE_NAME }}
       - name: Install poetry
         run: pipx install poetry
       - name: Set up Python

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Download results
         run: |
           gh release download results --pattern ${{ env.RESULTS_FILE_NAME }}
-          tar -xzf ${{ env.RESULTS_FILE_NAME }}
+          tar -xzvf ${{ env.RESULTS_FILE_NAME }}
       - name: Install poetry
         run: pipx install poetry
       - name: Set up Python

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -51,5 +51,5 @@ jobs:
           LAST_UPDATE=$(date --utc --date "@$(jq .last_update ./results/meta.json)")
           gh release edit results \
             --title "Results from $LAST_UPDATE" \
-            --notes "`results.tar.gz` of this release contains the latest results as of $LAST_UPDATE"
+            --notes "\`results.tar.gz\` of this release contains the latest results as of $LAST_UPDATE"
           gh release upload results ${{ env.RESULTS_FILE_NAME }} --clobber

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -13,7 +13,7 @@ permissions:
   contents: write
 
 env:
-  BACKEND_PATH: backend
+  RESULTS_FILE_NAME: results.tar.gz
 
 jobs:
   run:
@@ -21,13 +21,13 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ${{ env.BACKEND_PATH }}
+        working-directory: backend/
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
-        with:
-          ref: results
-          path: ${{ env.BACKEND_PATH}}/results
+      - name: Download results
+        run: |
+          gh release download results --pattern ${{ env.RESULTS_FILE_NAME }}
+          tar -xzf ${{ env.RESULTS_FILE_NAME }}
       - name: Install poetry
         run: pipx install poetry
       - name: Set up Python
@@ -45,12 +45,10 @@ jobs:
           GPU_TOKEN: ${{ secrets.GPU_TOKEN }}
         run: poetry run xbox-cloud-statistics | tee -a $GITHUB_STEP_SUMMARY
       - name: Persist results
-        working-directory: ${{ env.BACKEND_PATH}}/results
         run: |
-          LAST_UPDATE=$(date --utc --date "@$(jq .last_update meta.json)")
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout --orphan work
-          git add .
-          git commit -m "Update results ($LAST_UPDATE)"
-          git push --force origin work:results
+          tar -czf ${{ env.RESULTS_FILE_NAME }} results/
+          LAST_UPDATE=$(date --utc --date "@$(jq .last_update ./results/meta.json)")
+          gh release edit results
+            --title "Results from $LAST_UPDATE"
+            --notes "`results.tar.gz` of this release contains the latest results as of $LAST_UPDATE"
+          gh release upload results ${{ env.RESULTS_FILE_NAME }} --clobber

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Download results
         run: |
           gh release download results --pattern ${{ env.RESULTS_FILE_NAME }}
-          tar -xzf ${{ env.RESULTS_FILE_NAME }}
+          tar -xzvf ${{ env.RESULTS_FILE_NAME }}
       - name: Install poetry
         run: pipx install poetry
       - name: Set up Python
@@ -47,7 +47,7 @@ jobs:
         run: poetry run xbox-cloud-statistics | tee -a $GITHUB_STEP_SUMMARY
       - name: Persist results
         run: |
-          tar -czf ${{ env.RESULTS_FILE_NAME }} results/
+          tar -czvf ${{ env.RESULTS_FILE_NAME }} results/
           LAST_UPDATE=$(date --utc --date "@$(jq .last_update ./results/meta.json)")
           gh release edit results \
             --title "Results from $LAST_UPDATE" \

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -13,6 +13,7 @@ permissions:
   contents: write
 
 env:
+  GH_TOKEN: ${{ github.token }}
   RESULTS_FILE_NAME: results.tar.gz
 
 jobs:

--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           tar -czf ${{ env.RESULTS_FILE_NAME }} results/
           LAST_UPDATE=$(date --utc --date "@$(jq .last_update ./results/meta.json)")
-          gh release edit results
-            --title "Results from $LAST_UPDATE"
+          gh release edit results \
+            --title "Results from $LAST_UPDATE" \
             --notes "`results.tar.gz` of this release contains the latest results as of $LAST_UPDATE"
           gh release upload results ${{ env.RESULTS_FILE_NAME }} --clobber


### PR DESCRIPTION
After a note from GitHub Support regarding the size of this repository, I decided to no longer store the results in the `results` branch.
Force-pushing (see https://github.com/n-thumann/xbox-cloud-statistics/pull/23) only marginally improved this issue, because all commits are still kept at GitHubs servers and just not longer show up in my repository list. This causes this repository to be over 150 GB on their servers, even though the size of code + results is much smaller (200 MB locally / 30 MB on their servers).

This PR implements storing them in a single release with the latest results being stored as the asset. Further runs will replace the old asset.