### PR TITLE
Change: Use run environment

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -20,6 +20,7 @@ jobs:
   run:
     name: Run xbox-cloud-statistics
     runs-on: ubuntu-latest
+    environment: run
     defaults:
       run:
         working-directory: backend/


### PR DESCRIPTION
This PR changes the run workflow to use the run environment. This improves security, because the secrets can be restricted to that environment.