### PR TITLE
Change: Explictly specify bash to enable pipefail

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -45,6 +45,7 @@ jobs:
           CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           F2P_TOKEN: ${{ secrets.F2P_TOKEN }}
           GPU_TOKEN: ${{ secrets.GPU_TOKEN }}
+        shell: bash
         run: poetry run xbox-cloud-statistics | tee -a $GITHUB_STEP_SUMMARY
       - name: Prepare results
         run: tar -czvf ${{ env.RESULTS_FILE_NAME }} results/


### PR DESCRIPTION
This PR changes the behavior of the run step to enable pipefail. This will be enabled by explicitly enabling `bash` as `shell` (see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#defaultsrunshell)