### PR TITLE
Change: Bump Python version to 3.12 in run workflow

### DIFF
--- a/.github/workflows/run.yml
+++ b/.github/workflows/run.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.12"
           cache: "poetry"
       - name: Install Dependencies
         run: poetry install --only main


### PR DESCRIPTION
This PR bumps the Python version in the run workflow to 3.12 to be on a par with the other workflows. This should also fix https://github.com/n-thumann/xbox-cloud-statistics/actions/runs/9134576365/job/25120385141.