### PR TITLE
Fix: Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: "pip"
-    directory: "/backend"
+    directory: "/"
     schedule:
       interval: "monthly"
-    groups:
-      backend-dependendcies:
-        patterns:
-          - "*"
-  - package-ecosystem: "pip"
-    directory: "/frontend"
-    schedule:
-      interval: "monthly"
-    groups:
-      frontend-dependendcies:
-        patterns:
-          - "*"


### PR DESCRIPTION
Since https://github.com/n-thumann/xbox-cloud-statistics/pull/74 there aren't separate projects for frontend and backend anymore. This PR adjusts Dependabot to that.