### PR TITLE
Change: Use Dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      python-dependendcies:
+        patterns:
+          - "*"


### PR DESCRIPTION
This PR fixes https://github.com/n-thumann/xbox-cloud-statistics/pull/79, which dropped the grouping of dependencies.